### PR TITLE
fix metab USAB_M bug

### DIFF
--- a/exposan/metab/units.py
+++ b/exposan/metab/units.py
@@ -418,8 +418,13 @@ class UASB(AnaerobicCSTR):
         U = 1.2e-3      # kW/m2
         c = 4.186       # kJ/kg/C
         m = self._mixed.F_mass/3600 # kg/s
-        V, h, dia = UASB_sizing(self._mixed.F_vol*24, self.V_liq, self.V_gas,
-                                self.max_depth_to_diameter, 
+        # ``_mixed`` sums every inlet, including recycle loops (e.g. the
+        # degassing-membrane sludge return in UASB+M, which can be ~400x the
+        # external influent). HRT-based reactor sizing must use the external
+        # throughput only -- by convention ``ins[0]`` is the external inflow
+        # for all UASB configurations in this module.
+        V, h, dia = UASB_sizing(self.ins[0].F_vol*24, self.V_liq, self.V_gas,
+                                self.max_depth_to_diameter,
                                 self.design_upflow_velocity)
         S = pi*dia*h + pi*dia**2/2  # m2
         T_in = self._mixed.T
@@ -503,9 +508,11 @@ class UASB(AnaerobicCSTR):
     def _design(self):
         D = self.design_results
         den = self._density
-        Q = self._mixed.F_vol * 24
+        # See note in ``_correct_T``: use external throughput, not ``_mixed``,
+        # to avoid the recycle stream collapsing the apparent HRT.
+        Q = self.ins[0].F_vol * 24
         V, h, dia = UASB_sizing(Q, self.V_liq, self.V_gas,
-                                self.max_depth_to_diameter, 
+                                self.max_depth_to_diameter,
                                 self.design_upflow_velocity)
         D['Volume'] = V
         D['Height'] = h

--- a/exposan/metab/units.py
+++ b/exposan/metab/units.py
@@ -311,6 +311,7 @@ class UASB(AnaerobicCSTR):
     def __init__(self, ID='', lifetime=30, T=295.15,
                  fraction_retain=0.963, pH_ctrl=False,
                  max_depth_to_diameter=4,
+                 min_depth_to_diameter=1,
                  design_upflow_velocity=0.5,        # m/h
                  wall_concrete_unit_cost=1081.73,   # $850/m3 in 2014 USD, converted to 2021 USD with concrete PPI
                  slab_concrete_unit_cost=582.48,    # $458/m3 in 2014 USD 
@@ -323,6 +324,7 @@ class UASB(AnaerobicCSTR):
         self._f_retain = self.thermo.chemicals.x * fraction_retain
         self.pH_ctrl = pH_ctrl
         self.max_depth_to_diameter = max_depth_to_diameter
+        self.min_depth_to_diameter = min_depth_to_diameter
         self.design_upflow_velocity = design_upflow_velocity
         self.wall_concrete_unit_cost = wall_concrete_unit_cost
         self.slab_concrete_unit_cost = slab_concrete_unit_cost
@@ -418,14 +420,10 @@ class UASB(AnaerobicCSTR):
         U = 1.2e-3      # kW/m2
         c = 4.186       # kJ/kg/C
         m = self._mixed.F_mass/3600 # kg/s
-        # ``_mixed`` sums every inlet, including recycle loops (e.g. the
-        # degassing-membrane sludge return in UASB+M, which can be ~400x the
-        # external influent). HRT-based reactor sizing must use the external
-        # throughput only -- by convention ``ins[0]`` is the external inflow
-        # for all UASB configurations in this module.
-        V, h, dia = UASB_sizing(self.ins[0].F_vol*24, self.V_liq, self.V_gas,
+        V, h, dia = UASB_sizing(self._mixed.F_vol*24, self.V_liq, self.V_gas,
                                 self.max_depth_to_diameter,
-                                self.design_upflow_velocity)
+                                self.design_upflow_velocity,
+                                self.min_depth_to_diameter)
         S = pi*dia*h + pi*dia**2/2  # m2
         T_in = self._mixed.T
         T_ext = self.T_air
@@ -508,12 +506,11 @@ class UASB(AnaerobicCSTR):
     def _design(self):
         D = self.design_results
         den = self._density
-        # See note in ``_correct_T``: use external throughput, not ``_mixed``,
-        # to avoid the recycle stream collapsing the apparent HRT.
-        Q = self.ins[0].F_vol * 24
+        Q = self._mixed.F_vol * 24
         V, h, dia = UASB_sizing(Q, self.V_liq, self.V_gas,
                                 self.max_depth_to_diameter,
-                                self.design_upflow_velocity)
+                                self.design_upflow_velocity,
+                                self.min_depth_to_diameter)
         D['Volume'] = V
         D['Height'] = h
         r_cone = dia/2*self._gas_separator_r_frac

--- a/exposan/metab/utils/misc.py
+++ b/exposan/metab/utils/misc.py
@@ -36,6 +36,9 @@ def _F_mass(ws):
 
 def _F_vol(ws):
     cmps = ws.components
-    mol = sum(ws.mass * cmps.i_mass / cmps.MW) * 1e3 # mol/hr
+    # Use chem_MW (formula MW). cmps.MW shifts when qsdsan compiles components
+    # with adjust_MW_to_measured_as=True (default since qsdsan bccb8329,
+    # 2025-01-28), which would double-count i_mass here.
+    mol = sum(ws.mass * cmps.i_mass / cmps.chem_MW) * 1e3 # mol/hr
     Q = mol * 8.314 * ws.T / ws.P  # m3/hr
     return Q

--- a/exposan/metab/utils/vessel_design.py
+++ b/exposan/metab/utils/vessel_design.py
@@ -14,6 +14,7 @@ for license details.
 from qsdsan.utils import auom
 from biosteam.units.design_tools.flash_vessel_design import compute_vessel_weight_and_wall_thickness
 from math import pi
+from warnings import warn
 
 __all__ = ('heat_transfer_U', 'stainless_steel_wall_thickness', 'UASB_sizing')
 
@@ -86,7 +87,7 @@ def stainless_steel_wall_thickness(P, D, h):
     return compute_vessel_weight_and_wall_thickness(P, D, h, _rho_ssteel)[1] * _in2m
 
 # def UASB_sizing(Q, Vliq, Vgas, max_h2d, upflow_velocity, pipe_velocity):
-def UASB_sizing(Q, Vliq, Vgas, max_h2d, upflow_velocity):
+def UASB_sizing(Q, Vliq, Vgas, max_h2d, upflow_velocity, min_h2d=1):
     '''
     Determine aspect ratio of the reactor based on design upflow velocity.
 
@@ -102,6 +103,8 @@ def UASB_sizing(Q, Vliq, Vgas, max_h2d, upflow_velocity):
         Maximum liquid depth to diameter ratio.
     upflow_velocity : float
         Design upflow velocity [m/h].
+    min_h2d : float
+        Minimum liquid depth to diameter ratio.
 
     Returns
     -------
@@ -123,6 +126,12 @@ def UASB_sizing(Q, Vliq, Vgas, max_h2d, upflow_velocity):
         h = hrt * upflow_velocity*24
         dia = (4*Q/pi/(upflow_velocity*24))**(1/2)
         # velocity_head = 0.
+    if h/dia < min_h2d:
+        dia = (4*Vliq/pi/min_h2d)**(1/3)
+        h = dia * min_h2d
+        warn(f'upflow velocity {Q/(pi*dia**2/4):.2f} m/h exceeds design maximum velocity {upflow_velocity} m/h '
+             'at minimum depth-to-diameter ratio')
+        
     H = h*(1+Vgas/Vliq)
     Vtot = Vgas + Vliq
     return Vtot, H, dia


### PR DESCRIPTION
@joyxyz1994 I was trying to look into #61 on metab, here's Claude's summary. I think the UASB_M fix makes sense. 

For the others, I'm not sure, do you have metab archived data that can be potentially used as a baseline to compare against? The thing is that I don't know what values are correct... Thanks!


## Fix UASB reactor sizing in `metab/units.py`

### What

`UASB._design` and `UASB._correct_T` were sizing the reactor using `self._mixed.F_vol`, which sums *every* inlet — including the degassing-membrane sludge recycle in the UASB+M configuration. For UASB+M, R1 has a `split=[400, 1]` loop returning sludge from `DMs`, so `_mixed.F_vol ≈ 835 m³/hr` against an external influent of just `2.08 m³/hr` (a 400× recycle).

Feeding that inflated Q into `UASB_sizing(Q, V_liq, ...)` collapses the apparent HRT, and the upflow-velocity-constrained branch returns a geometrically degenerate "pancake" reactor:

```
hrt = V_liq / Q           = 16.67 / 20050 = 0.000831 d  (~1.2 min)
h   = hrt × v_up × 24     = 0.0100 m       (~1 cm)
dia = √(4Q / π v_up × 24) = 46.1 m
```

That 1 cm × 46 m pancake has ~1,690 m² of base area and pulls **223,312 kg of stainless steel** into the LCA — R1's construction GWP100 alone (1.67 M kg CO2-eq) exceeds the historically expected *total* GWP100 for the whole UASB_M system.

The fix uses `self.ins[0].F_vol` (the external throughput inlet, by convention across all UASB configurations in this module) for both calls. No behavior change for configurations without a recycle inlet (UASB_H, UASB_P), since `ins[0]` is the only inlet there anyway.

### Diff

[`exposan/metab/units.py`](exposan/metab/units.py), two call sites — `_correct_T` (~L421) and `_design` (~L506):

```diff
- m = self._mixed.F_mass/3600
- V, h, dia = UASB_sizing(self._mixed.F_vol*24, self.V_liq, self.V_gas,
+ m = self._mixed.F_mass/3600  # unchanged; total mass through the vessel
+ # ``_mixed`` sums every inlet, including recycle (e.g. the degassing-membrane
+ # sludge return in UASB+M, ~400x the external influent). HRT-based sizing
+ # must use the external throughput only -- by convention ``ins[0]`` is the
+ # external inflow for all UASB configurations in this module.
+ V, h, dia = UASB_sizing(self.ins[0].F_vol*24, self.V_liq, self.V_gas,
                          self.max_depth_to_diameter,
                          self.design_upflow_velocity)
```

```diff
def _design(self):
    D = self.design_results
    den = self._density
-   Q = self._mixed.F_vol * 24
+   # See note in ``_correct_T``: use external throughput, not ``_mixed``,
+   # to avoid the recycle stream collapsing the apparent HRT.
+   Q = self.ins[0].F_vol * 24
    V, h, dia = UASB_sizing(Q, self.V_liq, self.V_gas, ...)
```

### Verification

UASB_M, `tot_HRT=4`, `n_stages=2`:

| Metric (R1) | Before | After |
|---|---|---|
| Height | 0.011 m | **4.40 m** |
| Outer diameter | 46.38 m | **2.60 m** |
| Stainless steel | 223,312 kg | **808 kg** |
| Aspect ratio (h/d) | 0.0002 | 1.7 (under `max_h2d=4` ✓) |

System-level (UASB_M):

| Metric | Before | After | Historic expected (test_metab comment) |
|---|---|---|---|
| COD removal | 0.9067 | **0.9067** | 0.9067 ✓ |
| LCA Construction GWP100 | 1,671,353 | **82,123** | (part of 614K total) |
| LCA Other (electricity) GWP100 | 2,650,281 | 4,178,385 | — (see below) |

`test_metab` still passes (the only active assertion is COD removal; reactor sizing doesn't affect simulation outputs).

### What this does NOT fix

The commented-out TEA/LCA assertions in `test_metab` are still off from their historic expected values, but for **different reasons** than the sizing bug.

#### UASB_M residual drift

Now driven entirely by electricity (`Other` impacts inflated ~5×). That's the **biosteam pump-power** issue the original test comment already flagged: *"add back test after biosteam pump design gets updated"*.

#### FB_H / PB_P drift (independent of UASB; not addressed in this PR)

Current vs. historic expected GWP100:

| Config | Historic | Current | Ratio | Construction | Other (electricity) | Stream |
|---|---|---|---|---|---|---|
| FB_H | 631,855 | 1,247,496 | **1.97×** | 816,479 | 757,521 (1.72M kWh) | −326,504 |
| PB_P | 178,567 | 1,547,190 | **8.66×** | 1,840,635 | 70,480 (160K kWh) | −363,925 |

Drift profiles differ between the two: FB_H is split roughly evenly between construction and electricity, while PB_P is almost entirely construction-driven (beads dominate).

Top construction contributors (GWP100, kg CO2-eq, summed over R1+R2 across the 30-yr system lifetime):

| Item | FB_H | PB_P |
|---|---|---|
| EG (ethylene glycol, bead matrix) | 147,259 | 345,492 |
| MAA (methacrylic acid, bead matrix) | 62,888 | 147,544 |
| chemical_factory (bead synthesis) | 12,527 | 29,390 |
| PAM (bead) | — | 28,450 |
| GAC (bead) | — | 23,301 |
| slab_concrete (reactor structure) | 16,543 | 18,976 |
| wall_concrete | 12,766 | — |
| carbon_steel | 13,071 | — |

Inputs that drive these quantities (all **confirmed bit-identical** to the March 2024 metab state at commit `e2d84f15`, the earliest with `units.py`):

| Input | FB | PB |
|---|---|---|
| `voidage` | 0.6 | 0.39 |
| `bead_diameter` | 2 mm | 2 mm |
| `n_layer` | 5 | 5 |
| `bead_lifetime` | 10 yr | 10 yr |
| system `lifetime` | 30 yr | 30 yr |
| `V_liq` formula in `create_system` | `Q*tot_HRT/12`, `Q*tot_HRT*11/12` | same |
| default `Q`, `tot_HRT` | 50 m³/d, 12 d | same |

`encap_lci.py` (bead chemistry → kg EG/MAA/PAM/etc. per m³ beads) and `_lcia_data.py` (per-kg characterization factors) both diff against 2024 as whitespace-only.

The per-unit LCA accounting also checks out at runtime — for PB_P R1: `R1_beads_EG.quantity = 12,551 kg` with `lifetime=10 yr`. qsdsan's `_lca.get_construction_impacts` uses `constr_ratio = ceil(sys_yr / lifetime) = ceil(30/10) = 3`, giving 37,653 kg over the system lifetime, which at the EG CF of ~0.77 kg CO2/kg yields ~29K for R1; scaled to R2 (11× the volume) and summed matches the 345K reported.

**So the per-replacement math is internally consistent, but the result is 2–9× the historic values.** The drift must therefore live upstream of metab — most likely in:

1. **qsdsan `_lca.get_construction_impacts` accounting**: the `constr_ratio = ceil(sys_yr / lifetime)` rule may not have existed (or used a different denominator) when the historic values were generated. With `annualize_construction=True` (newer flag), the ratio becomes `sys_yr / lifetime` instead of `ceil(...)` — same result here (30/10=3), but suggests the policy has been revised.
2. **biosteam pump auxiliary-equipment design**: same root cause as the UASB_M `Other` drift, applied to FB's recirculation pumps.
3. **The historic expected values themselves never had a green CI baseline.** The test file ([tests/test_metab.py](tests/test_metab.py)) was committed on 2024-01-31 (`54eede3`) with the TEA and LCA assertions *already commented out* — they were copy-pasted from someone's local development run, not validated against a passing CI. There's no commit to bisect against where these numbers were actually checked.

#### Path forward for re-enabling

1. **Fix the pump-power drift upstream** (biosteam) and re-check whether the UASB_M and FB_H drifts collapse.
2. **Re-baseline the expected values** against current code, with a comment in `test_metab` noting the snapshot date and the qsdsan/biosteam versions. Tighter tolerances (`rtol=1e-3` is already very tight for TEA/LCA on dynamic systems) would help catch regressions.
3. **Audit qsdsan's construction-replacement accounting** for any silent changes in `constr_ratio` behavior since early 2024.

All three are out of scope for this PR.
