### PR TITLE
Fix htl bug related to ReversedSplitter

### DIFF
--- a/exposan/htl/systems.py
+++ b/exposan/htl/systems.py
@@ -172,8 +172,12 @@ def create_system(configuration='baseline', capacity=100,
     SP1 = qsu.ReversedSplitter('S200',ins=H2SO4_Tank-0, outs=('H2SO4_P','H2SO4_N'),
                                init_with='Stream')
     SP1.register_alias('SP1')
-    # must put after AcidEx and MemDis in path during simulation to ensure input
-    # not empty
+    # SP1.outs feed AcidEx/MemDis's own ins, so the network sorter always
+    # places SP1 before them (their real, non-reversed demand isn't known
+    # until they run). SP1.outs are declared as recycle streams below so the
+    # system iterates until AcidEx/MemDis's freshly-computed demand and
+    # SP1's split agree, instead of SP1 reading whatever demand was left
+    # over from the previous simulate() call.
     
     if configuration == 'no_P':
         M1_outs1 = ''
@@ -237,7 +241,8 @@ def create_system(configuration='baseline', capacity=100,
     
     RSP1 = qsu.ReversedSplitter('S300', ins='H2', outs=('HT_H2','HC_H2'),
                                 init_with='WasteStream')
-    # reversed splitter, write before HT and HC, simulate after HT and HC
+    # same reversed-splitter-before-its-demand situation as SP1 above;
+    # RSP1.outs are declared as recycle streams below.
     RSP1.ins[0].price = 1.61
     RSP1.register_alias('RSP1')
     
@@ -417,6 +422,19 @@ def create_system(configuration='baseline', capacity=100,
         operating_hours=WWTP.operation_hours, # 7920 hr Jones
         )
     sys.register_alias('sys')
+
+    # SP1/RSP1 (ReversedSplitter) run before AcidEx/MemDis/HT/HC compute their
+    # own reagent demand (see comments at SP1/RSP1 above), so without an
+    # explicit recycle the split reflects whatever demand was left over from
+    # the *previous* simulate() call, not the current one -- most visible
+    # (>1000x off) when repeatedly resimulating the same System object at
+    # very different scales, e.g. across Model parameter draws. Declaring
+    # these streams as a recycle makes the system iterate path in full until
+    # the split and the demand agree; the default recycle tolerance is
+    # loose enough to falsely call this "converged" after a single pass, so
+    # it's tightened here too.
+    sys.recycle = (SP1.outs[0], SP1.outs[1], RSP1.outs[0], RSP1.outs[1])
+    sys.set_tolerance(mol=1e-6, rmol=1e-9, maxiter=200)
 
     ##### Add stream impact items #####
 

--- a/tests/test_htl.py
+++ b/tests/test_htl.py
@@ -13,7 +13,7 @@ Please refer to https://github.com/QSD-Group/EXPOsan/blob/main/LICENSE.txt
 for license details.
 '''
 
-__all__ = ('test_htl',)
+__all__ = ('test_htl', 'test_htl_reversed_splitter_recycle')
 
 
 def _assert_allclose_any(actual, options, rtol):
@@ -78,5 +78,41 @@ def test_htl():
                           [2.027, -68.043, 46.295, 291.694]], rtol)
 
 
+def test_htl_reversed_splitter_recycle():
+    '''
+    SP1/RSP1 (``ReversedSplitter``, H2SO4/H2 makeup) compute their split from
+    AcidEx/MemDis/HT/HC's demand, but those units run *after* them in the
+    network path -- so without an explicit recycle, resimulating the same
+    ``System`` at a new ``plant_size`` reports the previous evaluation's
+    demand, not the current one. Regression test for that: evaluating the
+    same plant_size twice, with a very different plant_size evaluated in
+    between, must give the same result both times.
+    '''
+    from numpy.testing import assert_allclose
+    from chaospy import distributions as shape
+    from exposan.htl import create_model
+
+    model = create_model(
+        plant_size=True, feedstock='sludge', include_CFs_as_metrics=False,
+        include_other_metrics=False, include_other_CFs_as_metrics=False,
+        )
+    plant_size = model.parameters[-1]
+    MDSP, GWP = [m for m in model.metrics if m.name in ('MDSP', 'GWP diesel')]
+
+    plant_size.baseline = 150
+    model.metrics_at_baseline()
+    first = (MDSP.get(), GWP.get())
+
+    plant_size.baseline = 800 # a very different scale in between
+    model.metrics_at_baseline()
+
+    plant_size.baseline = 150 # back to the original scale
+    model.metrics_at_baseline()
+    second = (MDSP.get(), GWP.get())
+
+    assert_allclose(second, first, rtol=1e-3)
+
+
 if __name__ == '__main__':
     test_htl()
+    test_htl_reversed_splitter_recycle()


### PR DESCRIPTION
@jiananf2 

FYI, found this bug while doing some web app development. 

Currently, `SP1`/`RSP1` (ReversedSplitter units computing H2SO4 and H2 makeup) execute before `AcidEx`/`MemDis`/`HT`/`HC` determine the actual demand those splits are supposed to satisfy. So right now ReversedSplitter._run() just sums whatever its downstream units' demand streams held from the **previous simulate()** call. Resimulating the same System at conditions very different from the previous one (e.g., very different scales) will use last call's reagent flows, therefore the results can be very off.

The fix here declares `SP1.outs`/`RSP1.outs` as `sys.recycle` and tighten tolerance, so the system iterates to a self-consistent split within one `simulate()` call regardless of starting state.

I added a test for it.